### PR TITLE
Meta updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "comquest",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comquest",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Composable requests with redux thunk and axios",
   "main": "./dist/index.js",
   "module": "./es/index.js",

--- a/src/create-comquest-clear-request-data-action.ts
+++ b/src/create-comquest-clear-request-data-action.ts
@@ -11,7 +11,8 @@ export function createComquestClearRequestDataAction(
     type: actionTypes.CLEAR_REQUEST_DATA,
     meta: {
       comquest: COMQUEST_MAGIC_SYMBOL,
-      type: COMQUEST_CLEAR_REQUEST_DATA,
+      comquestActionType: COMQUEST_CLEAR_REQUEST_DATA,
+      comquestActionTypes: actionTypes,
     },
   });
 }

--- a/src/create-comquest-clear-request-errors-action.ts
+++ b/src/create-comquest-clear-request-errors-action.ts
@@ -11,7 +11,8 @@ export function createComquestClearRequestErrorsAction(
     type: actionTypes.CLEAR_REQUEST_ERRORS,
     meta: {
       comquest: COMQUEST_MAGIC_SYMBOL,
-      type: COMQUEST_CLEAR_REQUEST_ERRORS,
+      comquestActionType: COMQUEST_CLEAR_REQUEST_ERRORS,
+      comquestActionTypes: actionTypes,
     },
   });
 }

--- a/src/create-comquest-reset-request-state-action.ts
+++ b/src/create-comquest-reset-request-state-action.ts
@@ -11,7 +11,8 @@ export function createComquestResetRequestStateAction(
     type: actionTypes.RESET_REQUEST_STATE,
     meta: {
       comquest: COMQUEST_MAGIC_SYMBOL,
-      type: COMQUEST_RESET_REQUEST_STATE,
+      comquestActionType: COMQUEST_RESET_REQUEST_STATE,
+      comquestActionTypes: actionTypes,
     },
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,3 +21,8 @@ export {
 export {
   createComquestRequestStateReducer,
 } from './create-comquest-request-state-reducer';
+export {
+  isComquestAction,
+  isComquestSuccessAction,
+  isComquestFailureAction,
+} from './utils';

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,18 @@ export interface ComquestActionMeta<D = any, E = any> {
   readonly originalError?: E;
 }
 
+export type ComquestSuccessActionMeta<
+  D = AxiosResponse
+> = ComquestActionMeta & {
+  readonly originalData: D;
+  readonly originalError?: never;
+};
+
+export type ComquestFailureActionMeta<E = AxiosError> = ComquestActionMeta & {
+  readonly originalData?: never;
+  readonly originalError: E;
+};
+
 export interface ComquestAction<P = any, D = any, E = any> extends Action {
   readonly type: symbol;
   readonly payload?: P;
@@ -82,13 +94,21 @@ export interface ComquestAction<P = any, D = any, E = any> extends Action {
   readonly meta: ComquestActionMeta<D, E>;
 }
 
-export type ComquestSuccessAction<D = AxiosResponse> = ComquestAction<D> & {
-  readonly payload: D;
+export type ComquestSuccessAction<
+  P = AxiosResponse,
+  D = AxiosResponse
+> = ComquestAction<P> & {
+  readonly payload: P;
+  readonly meta: ComquestSuccessActionMeta<D>;
 };
 
-export type ComquestFailureAction<E = AxiosError> = ComquestAction<E> & {
+export type ComquestFailureAction<
+  P = AxiosError,
+  E = AxiosError
+> = ComquestAction<P> & {
   readonly error: true;
-  readonly payload: E;
+  readonly payload: P;
+  readonly meta: ComquestFailureActionMeta<E>;
 };
 
 export interface ComquestRequestState {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ import {
   AxiosResponse,
   CancelTokenSource,
 } from 'axios';
-import { AnyAction } from 'redux';
+import { Action } from 'redux';
 import { ThunkAction } from 'redux-thunk';
 
 export interface StringIndexedObject<T = any> {
@@ -63,7 +63,7 @@ export type ComquestRequestOptions = Partial<{
   // readonly resetRequestStateOnFailure: boolean;
 }>;
 
-export interface ComquestActionMeta {
+export interface ComquestActionMeta<D = any, E = any> {
   readonly comquest: symbol;
   readonly comquestActionType: symbol;
   readonly comquestActionTypes: ComquestActionTypes;
@@ -71,13 +71,15 @@ export interface ComquestActionMeta {
   readonly url?: string;
   readonly options?: ComquestRequestOptions;
   readonly config?: AxiosRequestConfig;
+  readonly originalData?: D;
+  readonly originalError?: E;
 }
 
-export interface ComquestAction<P = any> extends AnyAction {
+export interface ComquestAction<P = any, D = any, E = any> extends Action {
   readonly type: symbol;
   readonly payload?: P;
   readonly error?: boolean;
-  readonly meta: ComquestActionMeta;
+  readonly meta: ComquestActionMeta<D, E>;
 }
 
 export type ComquestSuccessAction<D = AxiosResponse> = ComquestAction<D> & {

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,7 @@ export type ComquestRequestOptions = Partial<{
 export interface ComquestActionMeta {
   readonly comquest: symbol;
   readonly comquestActionType: symbol;
+  readonly comquestActionTypes: ComquestActionTypes;
   readonly cancelTokenSource?: CancelTokenSource;
   readonly url?: string;
   readonly options?: ComquestRequestOptions;

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,6 +137,6 @@ export type ComquestActionCreatorCreator<S> = (
 export type ComquestActionCreator<S> = (
   configOverrides?: AxiosRequestConfig,
   optionsOverrides?: ComquestRequestOptions
-) => ThunkAction<ComquestPromise, S, undefined, AnyAction>;
+) => ThunkAction<ComquestPromise, S, undefined, ComquestAction>;
 
 export type ComquestPromise = Promise<AxiosResponse | AxiosError>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,7 +65,7 @@ export type ComquestRequestOptions = Partial<{
 
 export interface ComquestActionMeta {
   readonly comquest: symbol;
-  readonly type: symbol;
+  readonly comquestActionType: symbol;
   readonly cancelTokenSource?: CancelTokenSource;
   readonly url?: string;
   readonly options?: ComquestRequestOptions;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,11 +21,17 @@ export function isComquestAction<P = any>(
 export function isComquestSuccessAction<D = AxiosResponse>(
   action: any
 ): action is ComquestSuccessAction<D> {
-  return isComquestAction(action) && action.meta.type === COMQUEST_SUCCESS;
+  return (
+    isComquestAction(action) &&
+    action.meta.comquestActionType === COMQUEST_SUCCESS
+  );
 }
 
 export function isComquestFailureAction<E = AxiosError>(
   action: any
 ): action is ComquestFailureAction<E> {
-  return isComquestAction(action) && action.meta.type === COMQUEST_FAILURE;
+  return (
+    isComquestAction(action) &&
+    action.meta.comquestActionType === COMQUEST_FAILURE
+  );
 }

--- a/tests/create-comquest-clear-request-data-action.ts
+++ b/tests/create-comquest-clear-request-data-action.ts
@@ -20,7 +20,8 @@ describe('createComquestClearRequestDataAction', () => {
       type: actionTypes.CLEAR_REQUEST_DATA,
       meta: {
         comquest: COMQUEST_MAGIC_SYMBOL,
-        type: COMQUEST_CLEAR_REQUEST_DATA,
+        comquestActionType: COMQUEST_CLEAR_REQUEST_DATA,
+        comquestActionTypes: actionTypes,
       },
     });
   });

--- a/tests/create-comquest-clear-request-errors-action.ts
+++ b/tests/create-comquest-clear-request-errors-action.ts
@@ -20,7 +20,8 @@ describe('createComquestClearRequestErrorsAction', () => {
       type: actionTypes.CLEAR_REQUEST_ERRORS,
       meta: {
         comquest: COMQUEST_MAGIC_SYMBOL,
-        type: COMQUEST_CLEAR_REQUEST_ERRORS,
+        comquestActionType: COMQUEST_CLEAR_REQUEST_ERRORS,
+        comquestActionTypes: actionTypes,
       },
     });
   });

--- a/tests/create-comquest-reset-request-state-action.ts
+++ b/tests/create-comquest-reset-request-state-action.ts
@@ -20,7 +20,8 @@ describe('createComquestResetRequestStateAction', () => {
       type: actionTypes.RESET_REQUEST_STATE,
       meta: {
         comquest: COMQUEST_MAGIC_SYMBOL,
-        type: COMQUEST_RESET_REQUEST_STATE,
+        comquestActionType: COMQUEST_RESET_REQUEST_STATE,
+        comquestActionTypes: actionTypes,
       },
     });
   });

--- a/tests/imports.ts
+++ b/tests/imports.ts
@@ -4,8 +4,8 @@ import * as path from 'path';
 
 describe('tests', () => {
   const MATCHES_TS_FILE = /\.tsx?/;
-  const MATCHES_SRC_IMPORT = /from\s?'\.\.\/src(.*?)'/;
-  const MATCHES_EXCLUSIONS = /src\/(utils|constants)/;
+  const MATCHES_SRC_IMPORT = /from\s?'\.\.\/src(.*?)'/g;
+  const MATCHES_EXCLUSIONS = /src\/constants/;
 
   it('should only import from src directory', () => {
     const files = fs.readdirSync(__dirname);
@@ -19,14 +19,18 @@ describe('tests', () => {
         const fileName = path.basename(filePath);
         const contents = fs.readFileSync(resolvedPath, 'utf8');
 
-        const result = MATCHES_SRC_IMPORT.exec(contents);
+        let result = MATCHES_SRC_IMPORT.exec(contents);
 
-        if (result && result[1] && !MATCHES_EXCLUSIONS.test(result[0])) {
-          throw new Error(
-            `Test "${fileName}" did not import from '../src', instead imported ${
-              result[0]
-            }`
-          );
+        while (result) {
+          if (result && result[1] && !MATCHES_EXCLUSIONS.test(result[0])) {
+            throw new Error(
+              `Test "${fileName}" did not import from '../src', instead imported ${
+                result[0]
+              }`
+            );
+          }
+
+          result = MATCHES_SRC_IMPORT.exec(contents);
         }
       }
     });

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -12,6 +12,9 @@ describe('index.ts', () => {
     'createComquestRequestDataReducer',
     'createComquestRequestErrorReducer',
     'createComquestRequestStateReducer',
+    'isComquestAction',
+    'isComquestSuccessAction',
+    'isComquestFailureAction',
   ];
 
   it('exports all utilities', () => {

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -43,7 +43,7 @@ describe('utils', () => {
         isComquestFailureAction({
           meta: {
             comquest: COMQUEST_MAGIC_SYMBOL,
-            type: COMQUEST_REQUEST,
+            comquestActionType: COMQUEST_REQUEST,
           },
         } as any)
       ).toBe(false);
@@ -51,7 +51,7 @@ describe('utils', () => {
         isComquestFailureAction({
           meta: {
             comquest: COMQUEST_MAGIC_SYMBOL,
-            type: COMQUEST_FAILURE,
+            comquestActionType: COMQUEST_FAILURE,
           },
         })
       ).toBe(true);
@@ -71,7 +71,7 @@ describe('utils', () => {
         isComquestSuccessAction({
           meta: {
             comquest: COMQUEST_MAGIC_SYMBOL,
-            type: COMQUEST_REQUEST,
+            comquestActionType: COMQUEST_REQUEST,
           },
         } as any)
       ).toBe(false);
@@ -79,7 +79,7 @@ describe('utils', () => {
         isComquestSuccessAction({
           meta: {
             comquest: COMQUEST_MAGIC_SYMBOL,
-            type: COMQUEST_SUCCESS,
+            comquestActionType: COMQUEST_SUCCESS,
           },
         })
       ).toBe(true);

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,14 +1,14 @@
 import {
+  isComquestAction,
+  isComquestFailureAction,
+  isComquestSuccessAction,
+} from '../src';
+import {
   COMQUEST_FAILURE,
   COMQUEST_MAGIC_SYMBOL,
   COMQUEST_REQUEST,
   COMQUEST_SUCCESS,
 } from '../src/constants';
-import {
-  isComquestAction,
-  isComquestFailureAction,
-  isComquestSuccessAction,
-} from '../src/utils';
 
 describe('utils', () => {
   describe('isComquestAction', () => {


### PR DESCRIPTION
* Rename `meta.type` to `meta.comquestActionType`
* Add `meta.comquestActionTypes` to store `actionTypes` object
* Add `meta.originalData` and `meta.originalError` respectively
* Improve type checking in request action

Additional changes
* Export util functions from index
* Fix imports test & disallow utils imports